### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/base.h
+++ b/include/lsst/base.h
@@ -27,7 +27,7 @@
  *
  * Basic LSST definitions
  */
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 /**
  * A shared pointer to an object
@@ -38,12 +38,12 @@
  * \sa CONST_PTR
  */
 #define LSST_WHITESPACE /* White space to avoid swig converting vector<PTR(XX)> into vector<shared_ptr<XX>> */
-#define PTR(...) boost::shared_ptr<__VA_ARGS__ LSST_WHITESPACE > LSST_WHITESPACE
+#define PTR(...) std::shared_ptr<__VA_ARGS__ LSST_WHITESPACE > LSST_WHITESPACE
 /**
  * A shared pointer to a const object
  *
  * \sa PTR
  */
-#define CONST_PTR(...) boost::shared_ptr<const __VA_ARGS__ LSST_WHITESPACE > LSST_WHITESPACE
+#define CONST_PTR(...) std::shared_ptr<const __VA_ARGS__ LSST_WHITESPACE > LSST_WHITESPACE
 
 #endif


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
