### PR TITLE
loadSymbol: remove RTLD_LOCAL in dlopen

### DIFF
--- a/include/lsst/base/library.h
+++ b/include/lsst/base/library.h
@@ -53,7 +53,7 @@ T* loadSymbol(
     std::string const& symName          ///< Symbol name
     )
 {
-    void* lib = dlopen(getLibraryFilename(libName).c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    void* lib = dlopen(getLibraryFilename(libName).c_str(), RTLD_LAZY | RTLD_DEEPBIND);
     if (!lib) {
         throw LibraryException(libName);
     }


### PR DESCRIPTION
Mario Juric notes:
    Otherwise (at least on OS X) when a library opened as such is
    needed later by a different library, its symbols aren't found.

    In particular, this was a problem with MKL-enabled numpy on
    anaconda, causing errors such as this (when building ip-diffim):

    ====
    ImportError: dlopen(/Users/mjuric/projects/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/scipy/linalg/_fblas.so, 2): Symbol not found: ___kmpc_atomic_cmplx4_add
      Referenced from: /Users/mjuric/projects/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/scipy/linalg/../../../../libmkl_intel_thread.dylib
        Expected in: flat namespace
         in /Users/mjuric/projects/conda-lsst/miniconda/envs/_build/lib/python2.7/site-packages/scipy/linalg/../../../../libmkl_intel_thread.dylib
    ====

    The problem is easy to replicate in general, by importing the
    `_lsstcppimport` module, followed by importing `numpy`.

Removing RTLD_LOCAL fixes this on the Mac, and shouldn't impact Linux
because it is the default there.