### PR TITLE
DM-7893: Add exception safety tag to Doxygen

### DIFF
--- a/doc/base.inc
+++ b/doc/base.inc
@@ -218,7 +218,7 @@ TAB_SIZE               = 8
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES                = exceptsafe="@par Exception Safety\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
The tag is formatted to appear consistent with built-in Doxygen headers like "Parameters" or "Exceptions". It will be documented in the coming C++ documentation guide overhaul.

The behavior of the new tag was tested locally using an `afw` build and the ticket branch of `base`.