### PR TITLE
DM-9049: Enable autolinking in Doxygen

### DIFF
--- a/doc/base.inc
+++ b/doc/base.inc
@@ -286,7 +286,7 @@ MARKDOWN_SUPPORT       = YES
 # or globally by setting AUTOLINK_SUPPORT to NO.
 # The default value is: YES.
 
-AUTOLINK_SUPPORT       = NO
+AUTOLINK_SUPPORT       = YES
 
 # If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
 # to include (a tag file for) the STL sources as input, then you should set this


### PR DESCRIPTION
Autolinking has been re-enabled for LSST Doxygen builds, so we no longer need to prefix cross-references with `@ref`. Documentation that already uses `@ref` will compile unchanged.