### PR TITLE
Review for DM-9439: Package version checking is non-deterministic

### DIFF
--- a/python/lsst/base/packages.py
+++ b/python/lsst/base/packages.py
@@ -74,7 +74,8 @@ def getVersionFromPythonModule(module):
         deps = module.__dependency_versions__
         buildtime = BUILDTIME & set(deps.keys())
         if buildtime:
-            version += " with " + " ".join("%s=%s" % (pkg, deps[pkg]) for pkg in buildtime)
+            version += " with " + " ".join("%s=%s" % (pkg, deps[pkg])
+                                           for pkg in sorted(buildtime))
     return version
 
 


### PR DESCRIPTION
Since we're reading from a set, the order of iteration isn't otherwise
guaranteed. Different order means different version string and hence spurious
failures.