### PR TITLE
DM-4953: Don't print lsstcppimport err message if we're inside Scons.

### DIFF
--- a/python/lsstimport.py
+++ b/python/lsstimport.py
@@ -112,6 +112,16 @@ if 'orig_imp_load_module' not in locals():
 try:
     import lsstcppimport
 except ImportError:
-    print(
-        "Could not import lsstcppimport; please ensure the base package has been built (not just setup).\n",
-        file=sys.stderr)
+    # The lsstcppimport may have failed because we're inside Scons.
+    # If we are, then don't worry about it
+    try:
+        import SCons.Script
+    # If we're not, then
+    #   a) we will get an ImportError trying to import SCons.Script
+    #   b) and will know that the first ImportError really is a problem
+    #        and we should let the user know.
+    except ImportError:
+        print(
+            "Could not import lsstcppimport;"
+            " please ensure the base package has been built (not just setup).\n",
+            file=sys.stderr)


### PR DESCRIPTION
I added a check that tries to `import SCons.Script` to check to see if we're in Scons.  If we are, then no worries.  If we're not, then still print out the warning to STDERR.

@timj Does this look right?