### PR TITLE
Install python3 library aliases

### DIFF
--- a/python/lsstimport.py
+++ b/python/lsstimport.py
@@ -30,6 +30,15 @@ import functools
 import importlib
 import os.path
 
+# Ensure that the Python3 package library reorganization is available
+# to Python 2. It's okay if this doesn't work, and it won't work if SCons
+# is importing this and SCons has no access to the future package.
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
+
 # List of extensions to set global flags.  May need to be extended
 # for systems other than *nix and OSX.
 SHARED_LIB_EXTENSION_LIST = ('.so', '.dylib')


### PR DESCRIPTION
Do this here as it takes an effect globally and it means that we don't need to use it in higher level code where it can add complexity and linter warnings.