### PR TITLE
DM-9817: Doxygen tries to parse pybind11 wrappers

### DIFF
--- a/doc/base.inc
+++ b/doc/base.inc
@@ -836,8 +836,10 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
+# While pybind11 wrappers should be documented, Doxygen won't do it correctly
 EXCLUDE_PATTERNS       = */.svn \
-                         */.sconf_temp
+                         */.sconf_temp \
+                         */python/*.cc
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
This patch assumes that all C++ files in `python/` are for pybind11, and therefore cannot be parsed in a way that is useful to Doxygen. An alternative is to explicitly disable symbols like the `PYBIND11_PLUGIN` macro, but such an approach would likely lead to helper functions still being documented.

Changes have been tested by rebuilding the `afw` documentation with this branch, and looking for known instances of `PYBIND11_PLUGIN` documentation.