### PR TITLE
DM-11516: Let Doxygen report inherited methods inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config.log
 *.cfgc
 *.pyc
 .cache
+pytest_session.txt
 lib/libbase.*
 python/lsst/base/version.py
 python/lsst64defs.py

--- a/doc/base.inc
+++ b/doc/base.inc
@@ -123,7 +123,7 @@ ALWAYS_DETAILED_SEC    = NO
 # operators of the base classes will not be shown.
 # The default value is: NO.
 
-INLINE_INHERITED_MEMB  = NO
+INLINE_INHERITED_MEMB  = YES
 
 # If the FULL_PATH_NAMES tag is set to YES doxygen will prepend the full path
 # before files name in the file list and in the header files. If set to NO the


### PR DESCRIPTION
This change ensures that Doxygen-built and Python documentation will follow the same conventions in the new Sphinx system. I also ignore one temporary file that slipped in with the switch to `pytest`.