### PR TITLE
DM-28386: Switch order of python vs conda versions

### DIFF
--- a/python/lsst/base/packages.py
+++ b/python/lsst/base/packages.py
@@ -331,8 +331,8 @@ class Packages:
         packages : `Packages`
         """
         packages = {}
-        packages.update(getCondaPackages())
         packages.update(getPythonPackages())
+        packages.update(getCondaPackages())
         packages.update(getRuntimeVersions())
         packages.update(getEnvironmentPackages())  # Should be last, to override products with LOCAL versions
         return cls(packages)


### PR DESCRIPTION
We do not want the version string to change if a python package
is imported where the conda version has a different variant
(eg v1.3.0 vs 1.3.0) so first read the python imported versions
and then overwrite with the conda versions.